### PR TITLE
Plate conversion

### DIFF
--- a/merge.py
+++ b/merge.py
@@ -5,7 +5,7 @@ import json
 import argparse
 
 
-def update_zattrs(zarr_dir, rendering_json=None, dry_run=False):
+def update_zattrs(zarr_dir, omero_json=None, dry_run=False):
     rv = dict()
     if os.path.exists(f"{zarr_dir}/.zattrs"):
         with open(f"{zarr_dir}/.zattrs") as o:
@@ -17,18 +17,18 @@ def update_zattrs(zarr_dir, rendering_json=None, dry_run=False):
             multiscale["datasets"].append({"path": path})
         rv["multiscales"] = [multiscale]
 
-    if not rendering_json:
+    if not omero_json:
         with open(f"{zarr_dir}/omero.json", "r") as o:
-            rendering_json = json.load(o)
+            omero_json = json.load(o)
 
     rv["omero"] = {}
-    if "version" not in omero:
-        omero["version" ] = "0.1"
+    if "version" not in omero_json:
+        omero_json["version" ] = "0.1"
     for x in ("version", "channels", "rdefs"):
-        rv["omero"][x] = omero[x]
+        rv["omero"][x] = omero_json[x]
 
-    rv["omero"]["id"] = omero["id"]
-    rv["omero"]["name"] = omero["meta"]["imageName"]
+    rv["omero"]["id"] = omero_json["id"]
+    rv["omero"]["name"] = omero_json["meta"]["imageName"]
     for ch in rv["omero"]["channels"]:
         for x in ("reverseIntensity", "emissionWave"):
             ch.pop(x, None)
@@ -56,7 +56,7 @@ def get_zarr_directories(top_dirs, recursive):
     return(paths)
 
 
-def get_rendering_json(json_file):
+def get_omero_json(json_file):
     if json_file:
         with open(f"{json_file}", "r") as o:
             return json.load(o)
@@ -76,6 +76,6 @@ if __name__ == "__main__":
     args = p.parse_args()
 
     zarr_dirs = get_zarr_directories(args.dir, args.recursive)
-    rendering_json = get_rendering_json(args.file)
+    omero_json = get_omero_json(args.file)
     for zarr_dir in zarr_dirs:
-        update_zattrs(zarr_dir, rendering_json=rendering_json, dry_run=False)
+        update_zattrs(zarr_dir, omero_json=omero_json, dry_run=False)

--- a/merge.py
+++ b/merge.py
@@ -5,7 +5,7 @@ import json
 import argparse
 
 
-def update_zattrs(zarr_dir, rendering_json=None):
+def update_zattrs(zarr_dir, rendering_json=None, dry_run=False):
     rv = dict()
     if os.path.exists(f"{zarr_dir}/.zattrs"):
         with open(f"{zarr_dir}/.zattrs") as o:
@@ -35,6 +35,8 @@ def update_zattrs(zarr_dir, rendering_json=None):
     rv["omero"]["rdefs"].pop("invertAxis", None)
     rv["omero"]["rdefs"].pop("projection", None)
 
+    if args.dry_run:
+        print(f"Updating {zarr_dir}/.zattrs")
     with open(f"{zarr_dir}/.zattrs", "w") as o:
         o.write(json.dumps(rv, indent=4, sort_keys=True))
 
@@ -67,6 +69,8 @@ if __name__ == "__main__":
     p.add_argument("dir", nargs="+", help="the Zarr directory")
     p.add_argument("rendering_json_file", nargs="?",
                    help="a JSON file containing the rendering settings")
+    p.add_argument("--dry-run", "-n", action='store_true',
+                   help="dry-run")
     p.add_argument("--recursive", "-r", action='store_true',
                    help="apply recursively to all Zarr sub-directories")
     args = p.parse_args()
@@ -74,4 +78,4 @@ if __name__ == "__main__":
     zarr_dirs = get_zarr_directories(args)
     rendering_json = get_rendering_json(args)
     for zarr_dir in zarr_dirs:
-        update_zattrs(zarr_dir, rendering_json=rendering_json)
+        update_zattrs(zarr_dir, rendering_json=rendering_json, dry_run=False)

--- a/merge.py
+++ b/merge.py
@@ -1,13 +1,17 @@
 #!/usr/bin/env python
 import os
-import sys
 import glob
 import json
 import argparse
 p = argparse.ArgumentParser()
 p.add_argument("dir", nargs="+")
+p.add_argument("rendering_json", nargs="?")
 a = p.parse_args()
 rv = dict()
+
+if a.rendering_json:
+    with open(f"{a.rendering_json}", "r") as o:
+        omero = json.load(o)
 
 for dir in a.dir:
     if os.path.exists(f"{dir}/.zattrs"):
@@ -20,8 +24,9 @@ for dir in a.dir:
             multiscale["datasets"].append({"path": path})
         rv["multiscales"] = [multiscale]
 
-    with open(f"{dir}/omero.json", "r") as o:
-        omero = json.load(o)
+    if not a.rendering_json:
+        with open(f"{dir}/omero.json", "r") as o:
+            omero = json.load(o)
 
     rv["omero"] = {}
     if "version" not in omero:

--- a/merge.py
+++ b/merge.py
@@ -41,24 +41,24 @@ def update_zattrs(zarr_dir, rendering_json=None, dry_run=False):
         o.write(json.dumps(rv, indent=4, sort_keys=True))
 
 
-def get_zarr_directories(args):
-    if not args.recursive:
-       return args.dir
+def get_zarr_directories(top_dirs, recursive):
+    if not recursive:
+       return top_dirs
 
-    if len(args.dir) > 1:
+    if len(top_dirs) > 1:
         raise Exception("Recursive option can only be used with one directory")
 
     paths = []
-    for root, dirs, files in os.walk(args.dir[0]):
+    for root, dirs, files in os.walk(top_dirs[0]):
         for f in files:
             if f.lower() == '.zattrs':
                 paths.append(root)
     return(paths)
 
 
-def get_rendering_json(args):
-    if args.rendering_json_file:
-        with open(f"{a.rendering_json_file}", "r") as o:
+def get_rendering_json(json_file):
+    if json_file:
+        with open(f"{json_file}", "r") as o:
             return json.load(o)
     else:
         return None
@@ -67,7 +67,7 @@ def get_rendering_json(args):
 if __name__ == "__main__":
     p = argparse.ArgumentParser()
     p.add_argument("dir", nargs="+", help="the Zarr directory")
-    p.add_argument("rendering_json_file", nargs="?",
+    p.add_argument('--file',
                    help="a JSON file containing the rendering settings")
     p.add_argument("--dry-run", "-n", action='store_true',
                    help="dry-run")
@@ -75,7 +75,7 @@ if __name__ == "__main__":
                    help="apply recursively to all Zarr sub-directories")
     args = p.parse_args()
 
-    zarr_dirs = get_zarr_directories(args)
-    rendering_json = get_rendering_json(args)
+    zarr_dirs = get_zarr_directories(args.dir, args.recursive)
+    rendering_json = get_rendering_json(args.file)
     for zarr_dir in zarr_dirs:
         update_zattrs(zarr_dir, rendering_json=rendering_json, dry_run=False)


### PR DESCRIPTION
Ongoing set of improvements allowing to use these tools to convert plates

- bumps bioformats2raw to the current master (pre 0.3.0) including the HCS specification implementation https://github.com/glencoesoftware/bioformats2raw/pull/69
- refactors `merge.py` to consume a top-level rendering file and apply it recursively to all subfolders of a Zarr plate